### PR TITLE
Add compatibility for tree diagrams

### DIFF
--- a/plant-uml-file-viewer.js
+++ b/plant-uml-file-viewer.js
@@ -1,4 +1,4 @@
-var plantUmlSplitterRegex = /@startuml([\s\S]*?)@enduml/g;
+var plantUmlSplitterRegex = /(@startuml([\s\S]*?)@enduml)|(@startsalt([\s\S]*?)@endsalt)/g;
 
 var srcRawUrl = '/2.0/repositories/'
                         + getUrlParameter("repoPath")


### PR DESCRIPTION
Tree diagrams use `@startsalt`/`@endsalt` rather than `@startuml`/`@enduml`